### PR TITLE
Add support for laravel 11

### DIFF
--- a/.github/workflows/package-installation-tests.yml
+++ b/.github/workflows/package-installation-tests.yml
@@ -19,9 +19,14 @@ jobs:
         laravel:
           - "^9.0"
           - "^10.0"
+          # TODO This tag will be revised after official release
+          - "^11.x-dev"
         include:
           - option: --ignore-platform-req=php
             php: "8.4"
+        exclude:
+          - php: "8.1"
+            laravel: "^11.x-dev"
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         laravel:
           - "^9.0"
           - "^10.0"
+          - "^11.0"
         stability:
           - lowest
           - stable
@@ -31,6 +32,13 @@ jobs:
             stability: stable
           - option: --ignore-platform-req=php
             php: "8.4"
+          - unstable: 1
+            laravel: "^11.0"
+        exclude:
+          - laravel: "^11.0"
+            php: "8.1"
+          - laravel: "^11.0"
+            stability: lowest
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / ${{ matrix.stability }}
 
@@ -46,9 +54,18 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --ansi
-          composer update --prefer-${{ matrix.stability }} ${{ matrix.option }} --no-interaction --no-progress --ansi
+        run: composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --ansi
+
+      - name: Set minimum stability
+        if: ${{ matrix.unstable }}
+        run: composer config minimum-stability dev --ansi
+          
+      - name: Uninstall the package that is not compatible with Laravel 11
+        if: ${{ matrix.unstable }}
+        run: composer remove --dev vyuldashev/laravel-openapi --no-interaction --no-update
+          
+      - name: Install Composer dependencies
+        run: composer update --prefer-${{ matrix.stability }} ${{ matrix.option }} --no-interaction --no-progress --ansi
 
       - name: Run Code Format Check
         if: ${{ matrix.current }}

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     "license": "MIT",
     "type": "library",
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "KentarouTakeda\\Laravel\\OpenApiValidator\\": "src/"
         }

--- a/composer.json
+++ b/composer.json
@@ -82,5 +82,6 @@
         ],
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi"
-    }
+    },
+    "prefer-stable": true
 }

--- a/src/SchemaRepository/L5SwaggerResolver.php
+++ b/src/SchemaRepository/L5SwaggerResolver.php
@@ -10,6 +10,8 @@ use KentarouTakeda\Laravel\OpenApiValidator\Exceptions\LackOfDependenciesExcepti
 use KentarouTakeda\Laravel\OpenApiValidator\ResolverInterface;
 use L5Swagger\GeneratorFactory;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isl5SwaggerInstalled;
+
 class L5SwaggerResolver implements ResolverInterface
 {
     private readonly GeneratorFactory $generatorFactory;
@@ -18,7 +20,7 @@ class L5SwaggerResolver implements ResolverInterface
         private readonly Repository $repository,
         private readonly Filesystem $filesystem,
     ) {
-        if (!class_exists(GeneratorFactory::class)) {
+        if (!isl5SwaggerInstalled()) {
             throw new LackOfDependenciesException('L5Swagger is not installed.', class: GeneratorFactory::class);
         }
 

--- a/src/SchemaRepository/LaravelOpenApiResolver.php
+++ b/src/SchemaRepository/LaravelOpenApiResolver.php
@@ -8,13 +8,15 @@ use KentarouTakeda\Laravel\OpenApiValidator\Exceptions\LackOfDependenciesExcepti
 use KentarouTakeda\Laravel\OpenApiValidator\ResolverInterface;
 use Vyuldashev\LaravelOpenApi\Generator;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isLaravelOpenAPIInstalled;
+
 class LaravelOpenApiResolver implements ResolverInterface
 {
     private readonly Generator $generator;
 
     public function __construct(
     ) {
-        if (!class_exists(Generator::class)) {
+        if (!isLaravelOpenAPIInstalled()) {
             throw new LackOfDependenciesException('Laravel OpenAPI is not installed.', class: Generator::class);
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace KentarouTakeda\Laravel\OpenApiValidator;
 
-use Composer\InstalledVersions;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use KentarouTakeda\Laravel\OpenApiValidator\Config\Config;
@@ -44,7 +43,7 @@ class ServiceProvider extends BaseServiceProvider
             ]);
         }
 
-        if (InstalledVersions::isInstalled('swagger-api/swagger-ui') && $config->getIsSwaggerUiEnabled()) {
+        if (isSwaggerUIInstalled() && $config->getIsSwaggerUiEnabled()) {
             $this->loadRoutesFrom(__DIR__.'/../routes/swagger-ui.php');
             $this->loadViewsFrom(__DIR__.'/../resources/views', 'openapi-validator');
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KentarouTakeda\Laravel\OpenApiValidator;
+
+use Composer\InstalledVersions;
+
+function isSwaggerUIInstalled(): bool
+{
+    return InstalledVersions::isInstalled('swagger-api/swagger-ui');
+}
+
+function isLaravelOpenAPIInstalled(): bool
+{
+    return InstalledVersions::isInstalled('vyuldashev/laravel-openapi');
+}
+
+function isl5SwaggerInstalled(): bool
+{
+    return InstalledVersions::isInstalled('darkaonline/l5-swagger');
+}

--- a/tests/Feature/Http/Controllers/DocumentControllerTest.php
+++ b/tests/Feature/Http/Controllers/DocumentControllerTest.php
@@ -7,6 +7,9 @@ namespace KentarouTakeda\Laravel\OpenApiValidator\Tests\Feature\Http\Controllers
 use Illuminate\Config\Repository;
 use KentarouTakeda\Laravel\OpenApiValidator\Tests\Feature\TestCase;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isLaravelOpenAPIInstalled;
+use function KentarouTakeda\Laravel\OpenApiValidator\isSwaggerUIInstalled;
+
 class DocumentControllerTest extends TestCase
 {
     protected function defineEnvironment($app)
@@ -14,6 +17,15 @@ class DocumentControllerTest extends TestCase
         tap($app['config'], fn (Repository $config) => $config->set(
             ['openapi-validator.is_swagger_ui_enabled' => true],
         ));
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!isSwaggerUIInstalled()) {
+            self::markTestSkipped('Swagger UI is not installed.');
+        }
+
+        parent::setUpBeforeClass();
     }
 
     /**
@@ -30,6 +42,10 @@ class DocumentControllerTest extends TestCase
      */
     public function viewShouldReturnDocument(): void
     {
+        if (!isLaravelOpenAPIInstalled()) {
+            $this->markTestSkipped('Laravel OpenAPI is not installed.');
+        }
+
         $this->get(route('openapi-validator.document.laravel-openapi'))
             ->assertOk()
             ->assertViewIs('openapi-validator::documents')

--- a/tests/Feature/SchemaRepository/L5SwaggerResolverTest.php
+++ b/tests/Feature/SchemaRepository/L5SwaggerResolverTest.php
@@ -13,11 +13,22 @@ use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Response;
 use OpenApi\Attributes\Schema;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isl5SwaggerInstalled;
+
 class L5SwaggerResolverTest extends TestCase
 {
     use TestWithTemporaryFilesTrait;
 
     private L5SwaggerResolver $l5SwaggerResolver;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!isl5SwaggerInstalled()) {
+            self::markTestSkipped('L5Swagger is not installed.');
+        }
+
+        parent::setUpBeforeClass();
+    }
 
     public function setUp(): void
     {

--- a/tests/Feature/SchemaRepository/LaravelOpenApiResolverTest.php
+++ b/tests/Feature/SchemaRepository/LaravelOpenApiResolverTest.php
@@ -10,9 +10,20 @@ use KentarouTakeda\Laravel\OpenApiValidator\Tests\Feature\TestCase;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation;
 use Vyuldashev\LaravelOpenApi\Attributes\PathItem;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isLaravelOpenAPIInstalled;
+
 class LaravelOpenApiResolverTest extends TestCase
 {
     private LaravelOpenApiResolver $laravelOpenApiResolver;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!isLaravelOpenAPIInstalled()) {
+            self::markTestSkipped('Laravel OpenAPI is not installed.');
+        }
+
+        parent::setUpBeforeClass();
+    }
 
     public function setUp(): void
     {

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -7,14 +7,25 @@ use L5Swagger\L5SwaggerServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Vyuldashev\LaravelOpenApi\OpenApiServiceProvider;
 
+use function KentarouTakeda\Laravel\OpenApiValidator\isl5SwaggerInstalled;
+use function KentarouTakeda\Laravel\OpenApiValidator\isLaravelOpenAPIInstalled;
+
 class TestCase extends BaseTestCase
 {
     protected function getPackageProviders($app)
     {
-        return [
-            L5SwaggerServiceProvider::class,
-            OpenApiServiceProvider::class,
+        $providers = [
             ServiceProvider::class,
         ];
+
+        if (isl5SwaggerInstalled()) {
+            $providers[] = L5SwaggerServiceProvider::class;
+        }
+
+        if (isLaravelOpenAPIInstalled()) {
+            $providers[] = OpenApiServiceProvider::class;
+        }
+
+        return $providers;
     }
 }


### PR DESCRIPTION
Package definitions in composer.json have always been supported. This change is the addition of a test target in CI.