### PR TITLE
Add Laravel Boost guidelines and skills

### DIFF
--- a/resources/boost/guidelines/openapi-validator.blade.php
+++ b/resources/boost/guidelines/openapi-validator.blade.php
@@ -1,0 +1,15 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+
+# OpenAPI Validator
+
+`kentaroutakeda/laravel-openapi-validator` is installed. Provides middleware for automatic request/response validation based on OpenAPI schema.
+
+## Core Concepts
+
+- Adding `OpenApiValidator::class` middleware to a route enables automatic request/response validation against the OpenAPI schema. Returns 400 for request errors, 500 for response errors.
+- With response validation enabled (default), normal-case tests alone are sufficient. The middleware guarantees schema conformance, so error-case tests for schema-covered validations are unnecessary. When `skipResponseValidation` is enabled, write separate response validation tests.
+- Request validations defined in the OpenAPI schema (type, required, format, etc.) are handled by the middleware, so duplicating them in FormRequest is unnecessary. For validations not covered by the schema (DB checks, authorization, business logic, etc.), use minimal FormRequest or controller logic per project conventions.
+
+See the `openapi-validator` skill for detailed usage and code examples.

--- a/resources/boost/skills/openapi-validator/SKILL.blade.php
+++ b/resources/boost/skills/openapi-validator/SKILL.blade.php
@@ -1,0 +1,270 @@
+---
+name: openapi-validator
+description: >-
+  Assists with request/response validation setup and testing based on OpenAPI schema.
+  Activated when creating/modifying API endpoints/routes, writing tests, configuring Schema Providers, or defining schemas.
+---
+
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+$isLaravelOpenApi = \KentarouTakeda\Laravel\OpenApiValidator\isLaravelOpenAPIInstalled();
+$isL5Swagger = \KentarouTakeda\Laravel\OpenApiValidator\isl5SwaggerInstalled();
+@endphp
+
+# OpenAPI Validator Detailed Guide
+
+## Middleware Setup
+
+```php
+Route::get('/example', ExampleController::class)
+    ->middleware(OpenApiValidator::class);
+```
+
+See `reference/config.md` for customization options.
+
+## Writing Tests
+
+With `skipResponseValidation` disabled (default), normal-case tests alone are sufficient. Passing tests guarantees schema conformance. When `skipResponseValidation: true`, write separate response validation tests.
+
+```php
+class UserControllerTest extends TestCase
+{
+    #[Test]
+    public function it_can_retrieve_user_information(): void
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/users/{$user->id}")
+            ->assertOk()
+            ->assertJsonStructure(['data' => ['id', 'name', 'email']]);
+    }
+}
+```
+
+@if($isL5Swagger)
+## Schema Provider: L5-Swagger
+
+Uses L5-Swagger. Define schemas by writing OpenAPI annotations in controllers.
+
+### Annotation Placement
+
+Placement principles:
+
+- Operation definitions (`OA\Get`, `OA\Post`, etc.), `OA\RequestBody`, and `OA\Response` go on controller methods. Reference response body schemas via `ref`
+- Response data `OA\Schema` goes on JsonResource (API resource classes). Follow project-specific conventions if a custom transformation layer exists
+
+### API Resource Class Example
+
+```php
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'User',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer'),
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'email', type: 'string'),
+    ]
+)]
+class UserResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}
+```
+
+### Controller Example
+
+```php
+use OpenApi\Attributes as OA;
+
+class UserController
+{
+    #[OA\Get(
+        path: '/users/{id}',
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'integer')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'User information',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'data', ref: '#/components/schemas/User'),
+                    ]
+                )
+            ),
+        ]
+    )]
+    public function show(int $id): UserResource
+    {
+        $user = User::findOrFail($id);
+
+        return new UserResource($user);
+    }
+}
+```
+
+### .env Configuration
+
+```ini
+OPENAPI_VALIDATOR_PROVIDER="l5-swagger"
+```
+@endif
+
+@if($isLaravelOpenApi)
+## Schema Provider: Laravel OpenAPI
+
+Uses Laravel OpenAPI. Define schemas with attributes and factory classes.
+
+### Controller Example
+
+```php
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+
+#[OpenApi\PathItem]
+class UserController
+{
+    #[OpenApi\Operation]
+    #[OpenApi\Parameters(factory: UserShowParameters::class)]
+    #[OpenApi\Response(factory: UserResponse::class)]
+    public function show(int $id): JsonResponse
+    {
+        $user = User::findOrFail($id);
+
+        return response()->json($user);
+    }
+}
+```
+
+### Parameter Factory Example
+
+```php
+use Vyuldashev\LaravelOpenApi\Factories\ParametersFactory;
+
+class UserShowParameters extends ParametersFactory
+{
+    public function build(): array
+    {
+        return [
+            Parameter::path()
+                ->name('id')
+                ->required()
+                ->schema(Schema::integer()),
+        ];
+    }
+}
+```
+
+### Response Factory Example
+
+```php
+class UserResponse extends ResponseFactory
+{
+    public function build(): Response
+    {
+        return Response::ok()
+            ->description('User information')
+            ->content(
+                MediaType::json()->schema(
+                    Schema::object()->properties(
+                        Schema::integer('id'),
+                        Schema::string('name'),
+                        Schema::string('email'),
+                    )
+                )
+            );
+    }
+}
+```
+
+### .env Configuration
+
+```ini
+OPENAPI_VALIDATOR_PROVIDER="laravel-openapi"
+```
+@endif
+
+@if(!$isLaravelOpenApi && !$isL5Swagger)
+## Schema Provider: Custom Resolver
+
+Uses a custom Schema Provider. Implement `ResolverInterface` to provide the schema.
+
+### Resolver Implementation
+
+```php
+class MyResolver implements ResolverInterface
+{
+    public function getJson(array $options): string
+    {
+        return File::get(base_path('openapi.json'));
+    }
+}
+```
+
+### Configuration (config/openapi-validator.php)
+
+Publish the config file and register the resolver:
+
+```bash
+{{ $assist->artisanCommand('openapi-validator:publish') }}
+```
+
+```php
+return [
+    'default' => 'my-resolver',
+
+    'providers' => [
+        'my-resolver' => [
+            'resolver' => MyResolver::class,
+            // Any additional keys are passed as the array argument to getJson()
+        ],
+    ],
+];
+```
+@endif
+
+## Caching and Deployment
+
+Schema caching is integrated with Laravel's optimize commands.
+
+```bash
+# Production deployment (includes OpenAPI schema caching)
+{{ $assist->artisanCommand('optimize') }}
+
+# Clear cache (development)
+{{ $assist->artisanCommand('optimize:clear') }}
+```
+
+Individual commands:
+
+```bash
+{{ $assist->artisanCommand('openapi-validator:cache') }}
+{{ $assist->artisanCommand('openapi-validator:clear') }}
+```
+
+## Error Response Format
+
+Validation errors follow [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) format:
+
+```json
+{
+    "title": "InvalidQueryArgs",
+    "detail": "Missing required argument \"status\" for Request [get /]",
+    "status": 400
+}
+```
+
+See `reference/config.md` for detailed configuration.

--- a/resources/boost/skills/openapi-validator/reference/config.md
+++ b/resources/boost/skills/openapi-validator/reference/config.md
@@ -1,0 +1,109 @@
+# OpenAPI Validator Configuration Reference
+
+## Environment Variables
+
+| Environment Variable | Default | Description |
+|---------|-----------|------|
+| `OPENAPI_VALIDATOR_PROVIDER` | `laravel-openapi` | Default Schema Provider name |
+| `OPENAPI_VALIDATOR_VALIDATE_ERROR_RESPONSES` | `true` | Whether to validate error responses |
+| `OPENAPI_VALIDATOR_RESPOND_WITH_ERROR_ON_RESPONSE_VALIDATION_FAILURE` | `APP_DEBUG` | Whether to respond with error on response validation failure |
+| `OPENAPI_VALIDATOR_ERROR_ON_NO_PATH` | `APP_DEBUG` | Whether to respond with error when path is not defined |
+| `OPENAPI_VALIDATOR_ENABLE_RENDERER_FOR_NON_VALIDATION_ERRORS` | `false` | Whether to render non-validation errors with this package's renderer |
+| `OPENAPI_VALIDATOR_INCLUDE_REQ_ERROR_IN_RESPONSE` | `true` | Whether to include request error details in response |
+| `OPENAPI_VALIDATOR_INCLUDE_RES_ERROR_IN_RESPONSE` | `APP_DEBUG` | Whether to include response error details in response |
+| `OPENAPI_VALIDATOR_INCLUDE_TRACE_IN_RESPONSE` | `APP_DEBUG` | Whether to include stack trace in response |
+| `OPENAPI_VALIDATOR_INCLUDE_ORIGINAL_RES_IN_RESPONSE` | `APP_DEBUG` | Whether to include original response in error response |
+| `OPENAPI_VALIDATOR_REQUEST_ERROR_LOG_LEVEL` | `info` | Log level for request errors |
+| `OPENAPI_VALIDATOR_RESPONSE_ERROR_LOG_LEVEL` | `warning` | Log level for response errors |
+| `OPENAPI_VALIDATOR_IS_SWAGGER_UI_ENABLED` | `APP_DEBUG` | Whether to enable Swagger UI |
+
+## Provider Settings
+
+### Laravel OpenAPI
+
+```php
+'laravel-openapi' => [
+    'resolver' => LaravelOpenApiResolver::class,
+    'collection' => 'default',
+],
+```
+
+### L5-Swagger
+
+```php
+'l5-swagger' => [
+    'resolver' => L5SwaggerResolver::class,
+    'documentation' => 'default',
+],
+```
+
+### Your own provider
+
+```php
+'my-resolver' => [
+    'resolver' => MyResolver::class,
+    // Any additional keys are passed as the array argument to getJson()
+],
+```
+
+## Middleware Options
+
+```php
+// Default
+Route::middleware(OpenApiValidator::class);
+
+// Customization example
+Route::middleware(OpenApiValidator::config(
+    // Provider name from config
+    provider: 'my-resolver',
+    // Skip response validation in production
+    skipResponseValidation: app()->isProduction(),
+));
+```
+
+## Events
+
+Events dispatched on validation errors:
+
+- `RequestValidationFailed` - On request validation failure
+- `ResponseValidationFailed` - On response validation failure
+
+Both events implement `ValidationFailedInterface`.
+
+```php
+class MyListener
+{
+    public function handle(RequestValidationFailed $event): void
+    {
+        // $event->getThrowable() - Validation exception
+        // $event->getRequest() - HTTP request
+    }
+}
+```
+
+## Error Response Customization
+
+To change from RFC 7807 format, implement `ErrorRendererInterface` and bind it in the container:
+
+```php
+class MyErrorRenderer implements ErrorRendererInterface
+{
+    public function render(
+        \Throwable $error,
+        Request $request,
+        ?Response $response = null,
+    ): Response {
+        return response()->json([
+            'error' => $error->getMessage(),
+        ], $response ? 500 : 400);
+    }
+}
+```
+
+```php
+// AppServiceProvider.php
+public function register(): void
+{
+    $this->app->bind(ErrorRendererInterface::class, MyErrorRenderer::class);
+}
+```


### PR DESCRIPTION
## Summary

- Add Boost guideline with a quick reference for the OpenAPI Validator middleware
- Add Boost skill with detailed guidance for middleware setup, test writing, and schema provider configuration
- Add configuration reference covering environment variables, middleware options, and events

## Details

Integrates the package with Laravel Boost, enabling AI coding assistants to provide context-aware guidance when working with openapi-validator.

### Guideline

Concise overview explaining that `OpenApiValidator::class` middleware enables automatic request/response validation, and that response validation
makes normal-case tests sufficient for schema conformance.

### Skill
Detailed guide activated when creating/modifying API endpoints, writing tests, or configuring schema providers. Dynamically adapts content based on
 the installed schema provider (L5-Swagger, Laravel OpenAPI, or custom resolver).

### Configuration Reference
Documents all environment variables, provider settings, middleware options, events, and error response customization.
